### PR TITLE
fixed process grepping fact for scaleio_state.rb

### DIFF
--- a/lib/facter/scaleio_state.rb
+++ b/lib/facter/scaleio_state.rb
@@ -3,7 +3,7 @@ require 'facter'
 Facter.add("scaleio_mdm_state") do
   setcode do
 
-	output = Facter::Core::Execution.exec('ps auxw | grep mdm | egrep -v "bash|grep mdm"')
+	output = Facter::Core::Execution.exec('pgrep mdm')
 
 	"Running" if output
   end
@@ -12,7 +12,7 @@ end
 Facter.add("scaleio_sds_state") do
   setcode do
 
-	output = Facter::Core::Execution.exec('ps auxw | grep sds | egrep -v "bash|grep sds"')
+	output = Facter::Core::Execution.exec('pgrep sds')
 
 	"Running" if output
   end


### PR DESCRIPTION
'ps auxw | grep mdm | egrep -v "bash|grep mdm"'
might give a false positive if your hostname contains “mdm” and any of your interfaces are mistakenly set as DHCP, as is the case in a Vagrant environment:

[vagrant@mdm1 ~]$ ps auxw | grep mdm | egrep -v "bash|grep mdm"
root       841  0.0  0.0   9120   124 ?        Ss   15:37   0:00 /sbin/dhclient -H mdm1 -1 -q -cf /etc/dhcp/dhclient-eth0.conf -lf /var/lib/dhclient/dhclient-eth0.leases -pf /var/run/dhclient-eth0.pid eth0
root      2209  4.3 57.4 1153416 586688 ?      SLl  15:37   0:03 /opt/emc/scaleio/mdm/bin/mdm-1.30.426.0 --log_dir /opt/emc/scaleio/mdm/bin/../logs --conf_file /opt/emc/scaleio/mdm/bin/../cfg/conf.txt

This means that even if the mdm process isn't running, since the fact only checks for output it will give a false positive.

With pgrep, you only get the process number, which tells you it’s running, which is what you want:

[vagrant@mdm1 ~]$ pgrep mdm
2209
[vagrant@mdm1 ~]$ pgrep sds
593
